### PR TITLE
feat: handle project sharing (export/import)

### DIFF
--- a/backend/src/api/project/controller.py
+++ b/backend/src/api/project/controller.py
@@ -8,6 +8,10 @@ from src.api.project import service
 from src.api.project.dto import (
     CurrentProjectResponse,
     ProjectCreateRequest,
+    ProjectExportRequest,
+    ProjectExportResponse,
+    ProjectImportRequest,
+    ProjectImportResponse,
     ProjectSummary,
 )
 from src.core.config import PROJECTS_DIR, AppConfig
@@ -56,3 +60,25 @@ def get_thumbnail(name: str) -> FileResponse:
     if not path.exists():
         raise HTTPException(status_code=404, detail="Thumbnail not found")
     return FileResponse(path, media_type="image/png")
+
+
+@router.post("/project/export")
+def export_project(req: ProjectExportRequest) -> ProjectExportResponse:
+    try:
+        project_dir, assets_copied = service.export_project(req.name)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return ProjectExportResponse(project_dir=project_dir, assets_copied=assets_copied)
+
+
+@router.post("/project/import")
+def import_project(req: ProjectImportRequest) -> ProjectImportResponse:
+    try:
+        name = service.import_project(req.git_url)
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Clone failed: {e}")
+    return ProjectImportResponse(name=name)

--- a/backend/src/api/project/dto.py
+++ b/backend/src/api/project/dto.py
@@ -14,3 +14,20 @@ class ProjectCreateRequest(BaseModel):
 
 class CurrentProjectResponse(BaseModel):
     current_project: str | None
+
+
+class ProjectExportRequest(BaseModel):
+    name: str
+
+
+class ProjectExportResponse(BaseModel):
+    project_dir: str
+    assets_copied: list[str]
+
+
+class ProjectImportRequest(BaseModel):
+    git_url: str
+
+
+class ProjectImportResponse(BaseModel):
+    name: str

--- a/backend/src/api/project/service.py
+++ b/backend/src/api/project/service.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import struct
+import subprocess
 import zlib
 from pathlib import Path
+from typing import Any
 
 from src.core.config import PROJECTS_DIR, CONFIG_PATH, AppConfig
 from src.core.graph import Graph
@@ -79,3 +82,167 @@ def start_project(name: str, manager: GraphManager) -> None:
 def close_project(manager: GraphManager) -> None:
     manager.reset(Graph(edges=[], nodes={}))
     CONFIG_PATH.write_text(AppConfig(current_project=None).model_dump_json(indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Export / Import
+# ---------------------------------------------------------------------------
+
+_PATH_SUFFIXES = {
+    ".pt",
+    ".pth",
+    ".pkl",
+    ".bin",
+    ".onnx",
+    ".safetensors",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".wav",
+    ".mp3",
+    ".json",
+    ".txt",
+    ".yaml",
+    ".yml",
+    ".vmd",
+}
+
+
+def _looks_like_path(value: str) -> bool:
+    """Heuristic: a string looks like a file path if it contains a separator
+    and points to an existing file, or has a known model/asset extension."""
+    if not isinstance(value, str) or not value:
+        return False
+    p = Path(value)
+    # Absolute path that exists
+    if p.is_absolute() and p.is_file():
+        return True
+    # Relative path with a known extension (e.g. "assets/dart_control/foo.pt")
+    if os.sep in value or "/" in value:
+        if p.suffix.lower() in _PATH_SUFFIXES:
+            return True
+    return False
+
+
+def _collect_paths(
+    obj: Any, prefix: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], str]]:
+    """Walk a JSON-like structure and return (key_path, value) for path-like strings."""
+    results: list[tuple[tuple[str, ...], str]] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            results.extend(_collect_paths(v, prefix + (k,)))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            results.extend(_collect_paths(v, prefix + (str(i),)))
+    elif isinstance(obj, str) and _looks_like_path(obj):
+        results.append((prefix, obj))
+    return results
+
+
+def _set_nested(obj: Any, key_path: tuple[str, ...], value: str) -> None:
+    """Set a value in a nested dict/list given a key path."""
+    for part in key_path[:-1]:
+        if isinstance(obj, list):
+            obj = obj[int(part)]
+        else:
+            obj = obj[part]
+    last = key_path[-1]
+    if isinstance(obj, list):
+        obj[int(last)] = value
+    else:
+        obj[last] = value
+
+
+def export_project(name: str) -> tuple[str, list[str]]:
+    """Prepare a project for sharing by copying assets and rewriting paths.
+
+    Returns (project_dir, list_of_copied_asset_filenames).
+    """
+    project_dir = PROJECTS_DIR / name
+    graph_path = project_dir / "graph.json"
+    if not graph_path.exists():
+        raise FileNotFoundError(f"Project '{name}' not found")
+
+    data = json.loads(graph_path.read_text())
+    assets_dir = project_dir / "assets"
+    copied: list[str] = []
+
+    for _node_id, node in data.get("nodes", {}).items():
+        init_args = node.get("init_args", {})
+        paths = _collect_paths(init_args)
+        for key_path, raw_path in paths:
+            src = Path(raw_path)
+            # Try resolving relative to backend working dir if not absolute
+            if not src.is_absolute():
+                # Could be relative to the backend repo root
+                candidates = [
+                    Path.cwd() / raw_path,
+                    Path(__file__).resolve().parent.parent.parent.parent / raw_path,
+                ]
+                src = next((c for c in candidates if c.is_file()), src)
+
+            if not src.is_file():
+                continue
+
+            # Determine a unique filename in assets/
+            dest_name = src.name
+            dest = assets_dir / dest_name
+            # Avoid collisions by prefixing with parent dir name
+            if dest.exists() and not dest.samefile(src):
+                dest_name = f"{src.parent.name}_{src.name}"
+                dest = assets_dir / dest_name
+
+            # Already in the project assets dir — skip copy
+            if dest.exists() and dest.samefile(src):
+                _set_nested(init_args, key_path, f"assets/{dest_name}")
+                continue
+
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            copied.append(dest_name)
+
+            # Rewrite the path in init_args to relative
+            _set_nested(init_args, key_path, f"assets/{dest_name}")
+
+    # Save the rewritten graph
+    graph_path.write_text(json.dumps(data, indent=2))
+
+    return str(project_dir), copied
+
+
+def import_project(git_url: str) -> str:
+    """Clone a git repository into the projects directory.
+
+    Returns the project name (repo directory name).
+    """
+    # Derive project name from the git URL
+    repo_name = git_url.rstrip("/").rsplit("/", 1)[-1]
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+
+    dest = PROJECTS_DIR / repo_name
+    if dest.exists():
+        raise FileExistsError(f"Project '{repo_name}' already exists")
+
+    PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        ["git", "clone", "--depth", "1", git_url, str(dest)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # Verify it has a graph.json
+    if not (dest / "graph.json").exists():
+        shutil.rmtree(dest)
+        raise FileNotFoundError(
+            "Cloned repository does not contain a graph.json at root"
+        )
+
+    # Write a placeholder thumbnail if none exists
+    if not (dest / "thumbnail.png").exists():
+        _write_placeholder_png(dest / "thumbnail.png")
+
+    return repo_name

--- a/frontend/src/components/project/ProjectChooser.tsx
+++ b/frontend/src/components/project/ProjectChooser.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Plus, Trash2, X } from "lucide-react";
+import { Download, Plus, Share2, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   fetchProjects,
   createProject,
   deleteProject,
   startProject,
+  exportProject,
+  importProject,
   projectThumbnailUrl,
   type ProjectSummary,
 } from "@/lib/api";
@@ -23,9 +25,17 @@ export function ProjectChooser({
 }: ProjectChooserProps) {
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
+  const [showExportResult, setShowExportResult] = useState<{
+    dir: string;
+    assets: string[];
+  } | null>(null);
   const [newName, setNewName] = useState("");
+  const [importUrl, setImportUrl] = useState("");
   const [creating, setCreating] = useState(false);
+  const [importing, setImporting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
 
   const refresh = useCallback(() => {
     fetchProjects().then(setProjects).catch(console.error);
@@ -38,6 +48,10 @@ export function ProjectChooser({
   useEffect(() => {
     if (showCreateModal) inputRef.current?.focus();
   }, [showCreateModal]);
+
+  useEffect(() => {
+    if (showImportModal) importInputRef.current?.focus();
+  }, [showImportModal]);
 
   const handleOpen = useCallback(
     async (name: string) => {
@@ -69,6 +83,37 @@ export function ProjectChooser({
     },
     [refresh],
   );
+
+  const handleExport = useCallback(
+    async (name: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      try {
+        const result = await exportProject(name);
+        setShowExportResult({ dir: result.project_dir, assets: result.assets_copied });
+      } catch (err) {
+        console.error(err);
+      }
+    },
+    [],
+  );
+
+  const handleImport = useCallback(async () => {
+    const url = importUrl.trim();
+    if (!url) return;
+    setImporting(true);
+    try {
+      const result = await importProject(url);
+      refresh();
+      setShowImportModal(false);
+      setImportUrl("");
+      await startProject(result.name);
+      onOpen(result.name);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setImporting(false);
+    }
+  }, [importUrl, refresh, onOpen]);
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-background text-foreground">
@@ -120,16 +165,27 @@ export function ProjectChooser({
               <span className="text-[13px] font-medium truncate w-full text-center tracking-tight text-white/80">
                 {p.name}
               </span>
-              <button
-                className={cn(
-                  "absolute top-2.5 right-2.5 p-1.5 rounded-lg",
-                  "opacity-0 transition-all duration-200 group-hover:opacity-100",
-                  "text-muted-foreground hover:text-destructive-foreground hover:bg-destructive/30",
-                )}
-                onClick={(e) => handleDelete(p.name, e)}
-              >
-                <Trash2 className="w-3.5 h-3.5" />
-              </button>
+              <div className="absolute top-2.5 right-2.5 flex gap-1 opacity-0 transition-all duration-200 group-hover:opacity-100">
+                <button
+                  className={cn(
+                    "p-1.5 rounded-lg",
+                    "text-muted-foreground hover:text-conduit hover:bg-conduit/20",
+                  )}
+                  onClick={(e) => handleExport(p.name, e)}
+                  title="Share project"
+                >
+                  <Share2 className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  className={cn(
+                    "p-1.5 rounded-lg",
+                    "text-muted-foreground hover:text-destructive-foreground hover:bg-destructive/30",
+                  )}
+                  onClick={(e) => handleDelete(p.name, e)}
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
             </button>
           ))}
 
@@ -151,8 +207,144 @@ export function ProjectChooser({
               New project
             </span>
           </button>
+
+          {/* Import project card */}
+          <button
+            className={cn(
+              "flex flex-col items-center justify-center rounded-2xl border border-dashed p-4 transition-all duration-200",
+              "border-muted-foreground/20 hover:border-conduit/30 hover:bg-glass-hover",
+            )}
+            onClick={() => {
+              setImportUrl("");
+              setShowImportModal(true);
+            }}
+          >
+            <div className="flex h-28 w-full items-center justify-center rounded-xl">
+              <Download className="w-8 h-8 text-muted-foreground/50" />
+            </div>
+            <span className="text-[13px] text-muted-foreground/60 tracking-tight">
+              Import project
+            </span>
+          </button>
         </div>
       </div>
+
+      {/* Import project modal */}
+      {showImportModal && (
+        <div
+          className="fixed inset-0 z-60 flex items-center justify-center bg-black/60 backdrop-blur-xs"
+          onClick={() => setShowImportModal(false)}
+        >
+          <div
+            className={cn(
+              "w-96 rounded-2xl border border-glass-border p-5",
+              "bg-glass backdrop-blur-xs backdrop-saturate-150",
+              "shadow-2xl shadow-black/40",
+              "flex flex-col gap-4",
+            )}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-sm font-semibold text-white">Import Project</h2>
+            <p className="text-[12px] text-muted-foreground">
+              Enter a git URL to clone a shared project.
+            </p>
+            <input
+              ref={importInputRef}
+              type="text"
+              placeholder="https://github.com/user/project.git"
+              value={importUrl}
+              onChange={(e) => setImportUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleImport();
+                if (e.key === "Escape") setShowImportModal(false);
+              }}
+              className={cn(
+                "h-9 w-full rounded-xl px-3 text-[13px]",
+                "bg-accent border border-glass-border",
+                "text-foreground placeholder:text-muted-foreground/50",
+                "focus:border-conduit/40 focus:outline-none transition-colors",
+              )}
+            />
+            <div className="flex items-center justify-end gap-2">
+              <button
+                onClick={() => setShowImportModal(false)}
+                className={cn(
+                  "h-8 rounded-xl px-4 text-[13px]",
+                  "text-muted-foreground transition-colors",
+                  "hover:bg-glass-hover hover:text-foreground",
+                )}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={!importUrl.trim() || importing}
+                className={cn(
+                  "h-8 rounded-xl px-4 text-[13px] font-medium transition-all duration-200",
+                  "bg-conduit/20 text-conduit",
+                  "hover:bg-conduit/30",
+                  "disabled:opacity-30 disabled:cursor-not-allowed",
+                )}
+              >
+                {importing ? "Importing..." : "Import"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Export result modal */}
+      {showExportResult && (
+        <div
+          className="fixed inset-0 z-60 flex items-center justify-center bg-black/60 backdrop-blur-xs"
+          onClick={() => setShowExportResult(null)}
+        >
+          <div
+            className={cn(
+              "w-96 rounded-2xl border border-glass-border p-5",
+              "bg-glass backdrop-blur-xs backdrop-saturate-150",
+              "shadow-2xl shadow-black/40",
+              "flex flex-col gap-4",
+            )}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-sm font-semibold text-white">Project Exported</h2>
+            <p className="text-[12px] text-muted-foreground">
+              Assets have been copied and paths rewritten. Your project is ready to share.
+            </p>
+            <div className="rounded-xl bg-accent border border-glass-border p-3">
+              <p className="text-[12px] text-muted-foreground mb-1">Project directory:</p>
+              <p className="text-[12px] text-white font-mono break-all">
+                {showExportResult.dir}
+              </p>
+            </div>
+            {showExportResult.assets.length > 0 && (
+              <div className="rounded-xl bg-accent border border-glass-border p-3">
+                <p className="text-[12px] text-muted-foreground mb-1">
+                  Assets copied ({showExportResult.assets.length}):
+                </p>
+                <ul className="text-[11px] text-white/70 font-mono space-y-0.5">
+                  {showExportResult.assets.map((a) => (
+                    <li key={a}>{a}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div className="flex justify-end">
+              <button
+                onClick={() => setShowExportResult(null)}
+                className={cn(
+                  "h-8 rounded-xl px-4 text-[13px] font-medium transition-all duration-200",
+                  "bg-conduit/20 text-conduit",
+                  "hover:bg-conduit/30",
+                )}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Create project modal */}
       {showCreateModal && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -190,6 +190,30 @@ export async function closeProject() {
   if (!res.ok) throw new Error(`Close project failed: ${res.status}`);
 }
 
+export async function exportProject(
+  name: string,
+): Promise<{ project_dir: string; assets_copied: string[] }> {
+  const res = await fetch("/project/export", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error(`Export project failed: ${res.status}`);
+  return res.json();
+}
+
+export async function importProject(
+  gitUrl: string,
+): Promise<{ name: string }> {
+  const res = await fetch("/project/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ git_url: gitUrl }),
+  });
+  if (!res.ok) throw new Error(`Import project failed: ${res.status}`);
+  return res.json();
+}
+
 export async function fetchCurrentProject(): Promise<{
   current_project: string | null;
 }> {


### PR DESCRIPTION
## Summary
- **Export**: `POST /project/export` scans a project's `graph.json` for file path references in node `init_args`, copies those files into a project-local `assets/` directory, and rewrites paths to relative `assets/<filename>` references so the project is portable
- **Import**: `POST /project/import` accepts a git URL, clones it (shallow) into `~/Documents/OpenNeuro/projects/`, and validates the repo contains a `graph.json`
- **Frontend**: Added Share button (per project card) and Import Project card in the ProjectChooser, with corresponding modals for export result and git URL input

Closes #84

## Test plan
- [ ] Create a project with a CharacterCard that uses a `path` init_arg pointing to an absolute file path
- [ ] Click Share on the project card -- verify assets are copied to `<project>/assets/` and `graph.json` paths are rewritten
- [ ] Push the exported project to a git repo
- [ ] On another machine (or after deleting the project), click Import and paste the git URL
- [ ] Verify the imported project opens and works with its bundled assets

Generated with [Claude Code](https://claude.com/claude-code)