### PR TITLE
Fix AsyncIO event reuse race condition

### DIFF
--- a/backend/src/core/graph.py
+++ b/backend/src/core/graph.py
@@ -386,10 +386,14 @@ class GraphManager:
                 if ident is not None:
                     get_log_store().register_thread(node_id=node_id, ident=ident)
 
-        # Notify WS listeners that UI channels are ready
+        # Notify WS listeners that UI channels are ready.
+        # Save old event, replace with fresh one, *then* wake waiters.
+        # This avoids a race where a coroutine calling wait() between
+        # set() and reassignment would block on the now-orphaned event.
         self._ui_version += 1
-        self._ui_changed.set()
+        old_event = self._ui_changed
         self._ui_changed = asyncio.Event()
+        old_event.set()
 
     @staticmethod
     def _build_tuple(tp: type | None, handles: dict[str, Any]) -> tuple[Any, ...]:


### PR DESCRIPTION
## Summary
- Fix race condition in `GraphManager.run()` where `_ui_changed` asyncio.Event was set then immediately replaced, orphaning coroutines that called `wait()` between `set()` and reassignment
- Now saves old event reference, assigns a fresh event, then sets the old one so all waiters are properly woken

## Test plan
- [ ] Verify WS listeners for UI channel changes still receive notifications after pipeline run
- [ ] Confirm no coroutines hang indefinitely on orphaned events under concurrent load

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)