### PR TITLE
Fix VAD monitor thread not awaited

### DIFF
--- a/backend/src/core/conduit/vad.py
+++ b/backend/src/core/conduit/vad.py
@@ -264,13 +264,16 @@ class VAD(ThreadedComponent[VADInputs, VADOutputs]):
         )
         monitor_thread.start()
 
-        for frame in inputs.audio(self):
-            if frame is None:
-                break
-            self._process_audio_frame(frame, outputs)
+        try:
+            for frame in inputs.audio(self):
+                if frame is None:
+                    break
+                self._process_audio_frame(frame, outputs)
 
-        if self._current_segment:
-            with self._lock:
-                self._finalize_segment(outputs)
+            if self._current_segment:
+                with self._lock:
+                    self._finalize_segment(outputs)
+        finally:
+            monitor_thread.join(timeout=2.0)
 
         print("[VAD] Voice Activity Detection stopped")


### PR DESCRIPTION
## Summary
- Wraps the VAD `run()` main loop in `try/finally` so the monitor thread is joined with a 2-second timeout on exit
- Prevents orphaned daemon threads when the component stops

## Test plan
- [ ] Run pipeline with VAD node, verify monitor thread is joined on stop (no thread leak)
- [ ] Verify VAD still finalizes segments correctly during normal operation

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)