### PR TITLE
Fix UI receiver sub-ID collision risk

### DIFF
--- a/backend/src/api/ui/controller.py
+++ b/backend/src/api/ui/controller.py
@@ -13,6 +13,7 @@ Outbound:
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import struct
 import threading
@@ -24,6 +25,8 @@ from src.core.channel import Receiver, UISender, UIReceiver
 from src.core.graph import GraphManager
 
 router = APIRouter(prefix="/ui")
+
+_sub_id_counter = itertools.count()
 
 
 def _resolve_ui_output_type(
@@ -87,7 +90,7 @@ async def _read_ui_output(
 ) -> None:
     """Async task: reads from a blocking Receiver and sends to the WebSocket."""
     thread_stop = threading.Event()
-    sub_id = id(object())
+    sub_id = next(_sub_id_counter)
     receiver._channel._register(sub_id)
 
     try:


### PR DESCRIPTION
## Summary
- Replace `id(object())` with `next(itertools.count())` in `backend/src/api/ui/controller.py` to eliminate sub-ID collisions caused by CPython reusing memory addresses after GC of temporary objects.

Closes #103

## Test plan
- [ ] Verify multiple concurrent WebSocket UI connections get unique sub-IDs
- [ ] Confirm existing UI channel read/write behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)