### PR TITLE
Fixing a minor thread bug when the graph is stopped during SETUP

### DIFF
--- a/backend/src/core/channel.py
+++ b/backend/src/core/channel.py
@@ -87,6 +87,11 @@ class Channel[T]:
             else:
                 if index >= self._offset + len(self._items):
                     return None
+            # Guard against stale index: if the subscriber was unwired and
+            # re-wired (or GC advanced past us) while we were waiting, the
+            # offset may have moved beyond our captured index.
+            if index < self._offset:
+                return None
             item = self._items[index - self._offset]
             self._cursors[sub_id] = index + 1
             self._gc()

--- a/backend/src/core/component.py
+++ b/backend/src/core/component.py
@@ -318,6 +318,8 @@ class ThreadedComponent[
         try:
             self._status = Status.SETUP
             self.setup()
+            if self._stop_event.is_set():
+                return
             self._status = Status.RUNNING
             self.run(inputs, outputs)
         except Exception:
@@ -329,8 +331,10 @@ class ThreadedComponent[
             self._status = Status.STOPPED
 
     def start(self, inputs: I, outputs: O) -> None:
-        if self.status == Status.RUNNING:
+        if self.status in (Status.RUNNING, Status.SETUP):
             return
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
         self._stop_event.clear()
         self._thread = threading.Thread(
             target=self._safe_run, args=(inputs, outputs), daemon=True


### PR DESCRIPTION
When the graph is stopped during SETUP, `start()` previously only catches Status.RUNNING and not Status.SETUP, resulting in a new thread starting despite the old one.

Added some guards, including the start() joining the old thread, plus a defensive _get_cursor guard in channel.py as a safety net. 